### PR TITLE
Fix misaligned match results with perl backend

### DIFF
--- a/regex-tool.el
+++ b/regex-tool.el
@@ -88,7 +88,7 @@ The `perl' backend talks to a perl subprocess to do the handling.\"
 (defun regex-render-perl (regex sample)
   (with-temp-buffer
     (insert (format "@lines = <DATA>;
-$line = join(\" \", @lines);
+$line = join(\"\", @lines);
 print \"(\";
 while ($line =~ m/%s/mg) {
   print \"(\", length($`), \" \", length($&), \" \";


### PR DESCRIPTION
Consider this source text:

```
98.249.190.144 - - [19/Jul/2012:20:33:04 +0200] "GET /news/8603-exclusive-jack-johnson\xD3sets2.looktothestars.org/photo/1303-oxfam/tiny_square.jpg?1263992329 HTTP/1.1" 404 322 "http://www.looktothestars.org/?lang=it" "Mozilla/5.0 (Windows; U; MSIE 9.0; Windows NT 9.0; en-US)"
98.249.190.144 - - [19/Jul/2012:20:33:04 +0200] "GET /cause/5-educat-tweet HTTP/1.1" 301 113 "http://www.looktothestars.org/?lang=en" "Mozilla/5.0 (Windows; U; MSIE 9.0; Windows NT 9.0; en-US)"
98.249.190.144 - - [19/Jul/2012:20:33:04 +0200] "GET /2064 HTTP/1.1" 404 322 "http://www.looktothestars.org/?lang=hu" "Mozilla/5.0 (Windows; U; MSIE 9.0; Windows NT 9.0; en-US)"
98.249.190.144 - - [19/Jul/2012:20:33:04 +0200] "GET /news/2601-dionne-warwicisteneradata, HTTP/1.1" 301 154 "http://www.facebook.com/plugins/like.php?href=http://www.looktothestars.org/news/2601-dionne-warwick-and-sinbad-headline-charity-event&send=false&layout=button_count&width=125&show_faces=false&action=recommend&colorscheme=light&font&height=21" "Mozilla/5.0 (Windows; U; MSIE 9.0; Windows NT 9.0; en-US)"
98.249.190.144 - - [19/Jul/2012:20:33:04 +0200] "GET /celebrity/tweet HTTP/1.1" 404 9 "http://www.looktothestars.org/?lang=fil" "Mozilla/5.0 (Windows; U; MSIE 9.0; Windows NT 9.0; en-US)"
```

and the regex:

```
(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) \S+ \S+ \[.*?\] "GET [^? ]*(?:\\x|\/\.\.?\/|[=,:\}\{\(\)])\S*? HTTP\/1\.1"
```

The second highlighted match (on line 4) does not match the beginning of the line. When matching in a large text, the highlighted matches become progressively more misaligned as one moves later in the text.

This commit fixes the issue.
