### PR TITLE
Escape quotes and matched backslashes in perl match results

### DIFF
--- a/regex-tool.el
+++ b/regex-tool.el
@@ -94,7 +94,9 @@ while ($line =~ m/%s/mg) {
   print \"(\", length($`), \" \", length($&), \" \";
   for $i (1 .. 20) {
     if ($$i) {
-      print \"(\", $i, \" . \\\"\", $$i, \"\\\") \";
+      my $group = $$i;
+      $group =~ s/([\\\\\"])/\\\\\\1/g;
+      print \"(\", $i, \" . \\\"\", $group, \"\\\") \";
     }
   }
   print \")\";


### PR DESCRIPTION
When matching text containing backslashes, e.g. "\n", the "Group" output will display this as a newline. To prevent this, we have perl escape any backslashes in the group output so that 'read will handle the expression correctly.

Further, if the matched text contains double quotes, the resulting sexp printed by the perl program is invalid, and so the `*Groups*` buffer is empty. This commit also fixes this second issue.
