### PR TITLE
Add ELPA Code header

### DIFF
--- a/regex-tool.el
+++ b/regex-tool.el
@@ -50,6 +50,8 @@
 ;; 1.1 - Don't die horribly if the user simply types '^' or '$'
 ;; 1.2 - Include cl.el at compile time
 
+;;; Code:
+
 (eval-when-compile
   (require 'cl))
 


### PR DESCRIPTION
This should stop a complete source listing from appearing in the package description.